### PR TITLE
Add switch button on document pages

### DIFF
--- a/src/components/Global.vue
+++ b/src/components/Global.vue
@@ -8,6 +8,8 @@
 
   const cheerio = require('cheerio');
   const DOC_URL_PREFIX = "https://raw.githubusercontent.com/apache/incubator-iotdb/";
+  const DOC_ENG_PREFIX = "/docs/Documentation";
+  const DOC_CHN_PREFIX = "/docs/Documentation-CHN";
   const DEFAULT_VERSION = "latest";
   const LATEST_STR = "latest";
   const SUPPORT_VERSION = {
@@ -44,6 +46,8 @@
     DEFAULT_VERSION,
     SUPPORT_VERSION,
     LATEST_STR,
+    DOC_ENG_PREFIX,
+    DOC_CHN_PREFIX,
     isReadyForPrerender
   }
 </script>

--- a/src/components/LanguageButton.vue
+++ b/src/components/LanguageButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <p class="language-button" v-if="eng==true">[切换到中文版本]</p>
+    <p class="language-button" v-else>[Switch to English Version]</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "LanguageButton",
+  props: ['eng']
+}
+</script>
+
+<style scoped>
+  .language-button {
+    text-align: right;
+    margin-right: 30px;
+    color: #fcac45;
+    cursor: pointer;
+  }
+</style>

--- a/src/views/Documents.vue
+++ b/src/views/Documents.vue
@@ -37,8 +37,9 @@
             <li><a style='color:#fcac45;'>{{chapter}}</a></li>
           </ul>
           <div class="text-field" id="text-content">
+            <language-button :eng="eng" @click.native="switchLanguage()" />
             <vue-markdown class="markdown-area" :source="document" :toc="true" :toc-anchor-link="true" toc-anchor-link-symbol=""></vue-markdown>
-            <p class="find-mistake">This documentation is open source. Find mistakes? Want to contribute? Go for it.</p>
+            <p class="find-mistake">This documentation is open source. Find mistakes? Want to contribute? <span class="go-to-development" @click="goToDevelopment()">Go for it.</span></p>
           </div>
           <div class="doc-footer">
             <span>Copyright © 2019 The Apache Software Foundation. Apache and the Apache feather logo are trademarks of The Apache Software Foundation.</span>
@@ -54,6 +55,7 @@
   import MarkDown from "vue-markdown"
   import axios from 'axios'
   import Global from '../components/Global'
+  import LanguageButton from '../components/LanguageButton'
 
   export default {
     name: "Documents",
@@ -66,10 +68,12 @@
         chapter: "",
         section: "",
         text: "",
+        eng: true
       }
     },
     components: {
       'vue-markdown': MarkDown,
+      'language-button': LanguageButton
     },
     created() {
       this.init();
@@ -114,7 +118,6 @@
         this.$route.params.section = "sec" + section.replace(/[^0-9]/ig, "");
         let url = "/Documents/" + this.getVersion() + "/" + this.getChapter() + "/" + this.getSection();
         this.$router.push(url);
-        history.go(0);
       },
       // get the version
       getVersion() {
@@ -131,24 +134,30 @@
       updateDocument(){
         this.text = this.getVersionString();
       },
+      switchLanguage()  {
+        this.eng = this.eng !== true;
+        this.fetchData();
+      },
       // use version and section to render markdown
       fetchData() {
+        const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
         let version = this.getVersion();
         if (version in Global.SUPPORT_VERSION) {
           let chapter = Number(this.getChapter().substr(4)) - 1;
           let section = Number(this.getSection().substr(3));
           let url = Global.SUPPORT_VERSION[version]['doc-prefix']+ Global.SUPPORT_VERSION[version]['branch'] +
-            "/docs/Documentation/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
+            Global.DOC_ENG_PREFIX + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
             Global.SUPPORT_VERSION[version]['content'];
           axios.get(url).then(() => {
             this.chapter = this.result[chapter][0].substr(2);
             this.section = this.result[chapter][section].trim().substr(3);
             url = Global.SUPPORT_VERSION[version]['doc-prefix'] + Global.SUPPORT_VERSION[version]['branch'] +
-              "/docs/Documentation/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
+              docLanguageUrl + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
               this.chapter.substr(8).replace(': ', '-') + "/" + this.section + ".md";
             axios.get(url)
               .then((response) => {
                 this.document = response.data;
+                document.getElementById("text-content").scrollTop = 0;
               })
               .catch(function (error) {
                 console.log(error);
@@ -164,7 +173,7 @@
         let version = this.getVersion();
         if (version in Global.SUPPORT_VERSION) {
           let url = Global.SUPPORT_VERSION[version]['doc-prefix'] + Global.SUPPORT_VERSION[version]['branch'] +
-            "/docs/Documentation/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
+            Global.DOC_ENG_PREFIX + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
             Global.SUPPORT_VERSION[version]['content'];
           axios.get(url).then((response) => {
             let rows = response.data.split("\n");
@@ -181,6 +190,9 @@
         } else {
           this.$router.push('/404');
         }
+      },
+      goToDevelopment() {
+        this.$router.push('/Development');
       }
     }
   }
@@ -226,7 +238,14 @@
   }
 
   .find-mistake {
+    margin-top: 50px;
     text-align: center;
+    color: #fcac45;
+  }
+
+  .go-to-development {
+    text-decoration: underline;
+    cursor: pointer;
   }
 
   .sidebar {

--- a/src/views/Example.vue
+++ b/src/views/Example.vue
@@ -4,6 +4,7 @@
       <div class="row">
         <div class="col-sm-8">
           <loading v-if="seen"></loading>
+          <language-button v-if="seen==false" :eng="eng" @click.native="switchLanguage()" />
           <vue-markdown v-if="seen==false" v-bind:source="md" :toc="true" :toc-anchor-link-symbol="toc" :postrender="parse"></vue-markdown>
         </div>
         <my-sidebar/>
@@ -21,8 +22,9 @@
   import SideBar from '../components/SideBar'
   import markdown from 'vue-markdown'
   import axios from 'axios'
-  import Golbal from '../components/Global'
+  import Global from '../components/Global'
   import LoadingBar from '../components/Loading'
+  import LanguageButton from '../components/LanguageButton'
 
   export default {
     name: "Example",
@@ -31,6 +33,7 @@
       'my-sidebar': SideBar,
       'vue-markdown': markdown,
       'loading': LoadingBar,
+      'language-button': LanguageButton
     },
     data() {
       return {
@@ -38,16 +41,22 @@
         md: "",
         toc: "",
         seen: true,
+        eng: true
       }
     },
     created() {
       this.fetchData();
     },
     methods: {
+      switchLanguage()  {
+        this.eng = this.eng !== true;
+        this.fetchData();
+      },
       fetchData() {
-        let url = Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-          Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-          "/docs/Documentation/OtherMaterial-Examples.md";
+        const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
+        let url = Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+          "/OtherMaterial-Examples.md";
         const pointer = this;
         this.seen = true;
         axios.get(url)
@@ -57,7 +66,7 @@
           })
       },
       parse(html){
-        return Golbal.isReadyForPrerender(html)
+        return Global.isReadyForPrerender(html)
       }
     }
   }

--- a/src/views/LatestDoc.vue
+++ b/src/views/LatestDoc.vue
@@ -4,6 +4,7 @@
       <div class="row markdown-body">
         <div class="col-sm-8">
           <loading v-if="seen"></loading>
+          <language-button v-if="seen==false" :eng="eng" @click.native="switchLanguage()" />
           <vue-markdown v-if="seen==false" v-bind:source="md" :toc="true" :toc-anchor-link-symbol="toc" :postrender="parse"></vue-markdown>
         </div>
         <my-sidebar/>
@@ -21,8 +22,9 @@
   import SideBar from '../components/SideBar'
   import markdown from 'vue-markdown'
   import axios from 'axios'
-  import Golbal from '../components/Global'
+  import Global from '../components/Global'
   import LoadingBar from '../components/Loading'
+  import LanguageButton from '../components/LanguageButton'
 
   export default {
     name: "Community",
@@ -31,13 +33,15 @@
       'my-sidebar': SideBar,
       'vue-markdown': markdown,
       'loading': LoadingBar,
+      'language-button': LanguageButton
     },
     data() {
       return {
         msg: 'Welcome to Community Page',
         md: "",
         toc: "",
-        seen: true
+        seen: true,
+        eng: true
       }
     },
     created() {
@@ -50,14 +54,19 @@
       content: function () {
         return this.$route.params.doc
       },
+      switchLanguage()  {
+        this.eng = this.eng !== true;
+        this.fetchData();
+      },
       fetchData() {
+        const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
         const dict = {
-          "Quick Start": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/QuickStart.md",
-          "Frequently asked questions": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            '/docs/Documentation/Frequently%20asked%20questions.md',
+          "Quick Start": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+            "/QuickStart.md",
+          "Frequently asked questions": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+            '/Frequently%20asked%20questions.md',
         };
         const content = this.content();
         let url = null;
@@ -75,7 +84,7 @@
           })
       },
       parse(html){
-        return Golbal.isReadyForPrerender(html)
+        return Global.isReadyForPrerender(html)
       }
     }
   }

--- a/src/views/SingleMaterial.vue
+++ b/src/views/SingleMaterial.vue
@@ -4,6 +4,7 @@
       <div class="row markdown-body">
         <div class="col-sm-8">
           <loading v-if="seen"></loading>
+          <language-button v-if="seen==false" :eng="eng" @click.native="switchLanguage()" />
           <vue-markdown  v-if="seen==false" v-bind:source="md" :toc="true" :toc-anchor-link-symbol="toc" :postrender="parse"></vue-markdown>
         </div>
         <my-sidebar/>
@@ -18,8 +19,9 @@
   import SideBar from '../components/SideBar'
   import markdown from 'vue-markdown'
   import axios from 'axios'
-  import Golbal from '../components/Global'
+  import Global from '../components/Global'
   import LoadingBar from '../components/Loading'
+  import LanguageButton from '../components/LanguageButton'
 
   export default {
     name: "SingleMaterial",
@@ -28,6 +30,7 @@
       'my-sidebar': SideBar,
       'vue-markdown': markdown,
       'loading': LoadingBar,
+      'language-button': LanguageButton
     },
     data() {
       return {
@@ -35,6 +38,7 @@
         md: "",
         toc: "",
         seen: true,
+        eng: true
       }
     },
     created() {
@@ -47,16 +51,21 @@
       content: function () {
         return this.$route.params.doc
       },
+      switchLanguage()  {
+        this.eng = this.eng !== true;
+        this.fetchData();
+      },
       fetchData() {
+        const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
         const dict = {
-          "Release Notes": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/OtherMaterial-ReleaseNotes"+
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['version']+
+          "Release Notes": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl  +
+            "/OtherMaterial-ReleaseNotes"+
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version']+
             ".md",
-          "References": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/OtherMaterial-Reference.md",
+          "References": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] +docLanguageUrl +
+            "/OtherMaterial-Reference.md",
         };
         const content = this.content();
         let url = null;
@@ -74,7 +83,7 @@
           })
       },
       parse(html){
-        return Golbal.isReadyForPrerender(html)
+        return Global.isReadyForPrerender(html)
       }
     }
   }

--- a/src/views/SingleTool.vue
+++ b/src/views/SingleTool.vue
@@ -4,6 +4,7 @@
       <div class="row markdown-body">
         <div class="col-sm-8">
           <loading v-if="seen"></loading>
+          <language-button v-if="seen==false" :eng="eng" @click.native="switchLanguage()" />
           <vue-markdown  v-if="seen==false" v-bind:source="md" :toc="true" :toc-anchor-link-symbol="toc" :postrender="parse"></vue-markdown>
         </div>
         <my-sidebar/>
@@ -21,8 +22,9 @@
   import SideBar from '../components/SideBar'
   import markdown from 'vue-markdown'
   import axios from 'axios'
-  import Golbal from '../components/Global'
+  import Global from '../components/Global'
   import LoadingBar from '../components/Loading'
+  import LanguageButton from '../components/LanguageButton'
 
   export default {
     name: "SingleTool",
@@ -31,6 +33,7 @@
       'my-sidebar': SideBar,
       'vue-markdown': markdown,
       'loading': LoadingBar,
+      'language-button': LanguageButton
     },
     data() {
       return {
@@ -38,6 +41,7 @@
         md: "",
         toc: "",
         seen: true,
+        eng: true
       }
     },
     created() {
@@ -50,27 +54,27 @@
       content: function () {
         return this.$route.params.content
       },
+      switchLanguage()  {
+        this.eng = this.eng !== true;
+        this.fetchData();
+      },
       fetchData() {
+        const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
         const dict = {
-          "Cli": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/UserGuide" +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['version'] + "/7-Tools-Cli.md",
-          "Grafana": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/UserGuide" +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['version'] + "/7-Tools-Grafana.md",
-          "Hadoop": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/UserGuide" +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['version'] + "/7-Tools-Hadoop.md",
-          "Spark": Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-            "/docs/Documentation/UserGuide" +
-            Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['version'] + "/7-Tools-spark.md",
+          "Cli": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/7-Tools-Cli.md",
+          "Grafana": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/7-Tools-Grafana.md",
+          "Hadoop": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/7-Tools-Hadoop.md",
+          "Spark": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
+          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/7-Tools-spark.md",
         };
         const content = this.content();
-        console.log(content);
         let url = null;
         if (content in dict) {
           url = dict[content];
@@ -86,7 +90,7 @@
           })
       },
       parse(html){
-        return Golbal.isReadyForPrerender(html)
+        return Global.isReadyForPrerender(html)
       }
     }
   }


### PR DESCRIPTION
To support switching documents between Chinese and English in official website:
1. A button component needs to be added in all documents page;
2. The urls of documents are generated by different languages.

Other changes are made in [this PR](https://github.com/apache/incubator-iotdb/pull/219).