### PR TITLE
Update documents url and method of loading nav sidebar content

### DIFF
--- a/src/components/Global.vue
+++ b/src/components/Global.vue
@@ -1,4 +1,6 @@
 <script>
+  import axios from 'axios'
+
   const downloadIotdbCli='https://github.com/apache/incubator-iotdb';
   const downloadGrafanaConnector='https://github.com/apache/incubator-iotdb';
   const downloadHadoopConnector='https://github.com/apache/incubator-iotdb';
@@ -14,28 +16,14 @@
       "doc-prefix": DOC_URL_PREFIX,
       'version': "V0.7.0",
       'text': "Latest",
-      'chapters': [
-        '1-Overview.md',
-        '2-Concept.md',
-        '3-Operation%20Manual.md',
-        '4-Deployment%20and%20Management.md',
-        '5-SQL%20Documentation.md',
-        '6-JDBC%20Documentation.md'
-      ]
+      'content': '0-Content.md'
     },
     "0.7.0": {
       "branch": "0.7.0-doc",
       "doc-prefix": DOC_URL_PREFIX,
       'version': "V0.7.0",
       'text': "V0.7.0",
-      'chapters': [
-        '1-Overview.md',
-        '2-Concept.md',
-        '3-Operation%20Manual.md',
-        '4-Deployment%20and%20Management.md',
-        '5-SQL%20Documentation.md',
-        '6-JDBC%20Documentation.md'
-      ]
+      'content': '0-Content.md'
     }
   };
 

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -105,7 +105,7 @@
       return {
         "Documents": [
           {"url": "/Documents/Quick Start", "content": "Quick Start"},
-          {"url": "/Documents/latest/sec1", "content": "User Guide"},
+          {"url": "/Documents/latest/chap1/sec1", "content": "User Guide"},
           {"url": "/Materials", "content": "Other Materials"},
           {"url": "/Documents/Frequently asked questions", "content": "Frequently asked questions"}
         ],

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,7 +33,7 @@ export default new Router({
       component: LatestDoc
     },
     {
-      path: '/Documents/:version/:section?',
+      path: '/Documents/:version/:chapter?/:section?',
       name: 'Documents',
       component: Documents
     },


### PR DESCRIPTION
This PR solves some small problems of official website:
1. The nav sidebar content of all chapter names are fixed by codes, so if the documents are changed in the future frequently, codes of the website would be updated manually, which is very inconvenient.
2. Clicking the elements in nav sidebar cannot jump to right position in some case.

To solve the problems,
1. Change documents url pattern from "/sec" to "/chap/sec", so that the router won't jump to 404 after refreshing the website;
2. Change method of loading nav sidebar content by "content.md", instead of fixed file names. Therefore, in the future, when the documents are updated frequently, the codes of the website needn't be changed.
3. Other changes are made in [this PR](https://github.com/apache/incubator-iotdb/pull/204).