### PR TITLE
Delete "version" in documents folder and url

### DIFF
--- a/src/components/Global.vue
+++ b/src/components/Global.vue
@@ -16,14 +16,12 @@
     "latest": {
       "branch": "master",
       "doc-prefix": DOC_URL_PREFIX,
-      'version': "V0.7.0",
       'text': "Latest",
       'content': '0-Content.md'
     },
     "0.7.0": {
       "branch": "0.7.0-doc",
       "doc-prefix": DOC_URL_PREFIX,
-      'version': "V0.7.0",
       'text': "V0.7.0",
       'content': '0-Content.md'
     }

--- a/src/components/Global.vue
+++ b/src/components/Global.vue
@@ -13,16 +13,10 @@
   const DEFAULT_VERSION = "latest";
   const LATEST_STR = "latest";
   const SUPPORT_VERSION = {
-    "latest": {
-      "branch": "master",
+    "0.8.0": {
+      "branch": "rel/0.8",
       "doc-prefix": DOC_URL_PREFIX,
-      'text': "Latest",
-      'content': '0-Content.md'
-    },
-    "0.7.0": {
-      "branch": "0.7.0-doc",
-      "doc-prefix": DOC_URL_PREFIX,
-      'text': "V0.7.0",
+      'text': "V0.8.0",
       'content': '0-Content.md'
     }
   };

--- a/src/views/Documents.vue
+++ b/src/views/Documents.vue
@@ -146,14 +146,12 @@
           let chapter = Number(this.getChapter().substr(4)) - 1;
           let section = Number(this.getSection().substr(3));
           let url = Global.SUPPORT_VERSION[version]['doc-prefix']+ Global.SUPPORT_VERSION[version]['branch'] +
-            Global.DOC_ENG_PREFIX + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
-            Global.SUPPORT_VERSION[version]['content'];
+            Global.DOC_ENG_PREFIX + "/UserGuide/" + Global.SUPPORT_VERSION[version]['content'];
           axios.get(url).then(() => {
             this.chapter = this.result[chapter][0].substr(2);
             this.section = this.result[chapter][section].trim().substr(3);
             url = Global.SUPPORT_VERSION[version]['doc-prefix'] + Global.SUPPORT_VERSION[version]['branch'] +
-              docLanguageUrl + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
-              this.chapter.substr(8).replace(': ', '-') + "/" + this.section + ".md";
+              docLanguageUrl + "/UserGuide/" + this.chapter.substr(8).replace(': ', '-') + "/" + this.section + ".md";
             axios.get(url)
               .then((response) => {
                 this.document = response.data;
@@ -173,8 +171,7 @@
         let version = this.getVersion();
         if (version in Global.SUPPORT_VERSION) {
           let url = Global.SUPPORT_VERSION[version]['doc-prefix'] + Global.SUPPORT_VERSION[version]['branch'] +
-            Global.DOC_ENG_PREFIX + "/UserGuide" + Global.SUPPORT_VERSION[version]['version'] + "/" +
-            Global.SUPPORT_VERSION[version]['content'];
+            Global.DOC_ENG_PREFIX + "/UserGuide/" + Global.SUPPORT_VERSION[version]['content'];
           axios.get(url).then((response) => {
             let rows = response.data.split("\n");
             let i = -1;

--- a/src/views/SingleMaterial.vue
+++ b/src/views/SingleMaterial.vue
@@ -59,12 +59,9 @@
         const docLanguageUrl = this.eng ? Global.DOC_ENG_PREFIX : Global.DOC_CHN_PREFIX;
         const dict = {
           "Release Notes": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
-            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl  +
-            "/OtherMaterial-ReleaseNotes"+
-            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version']+
-            ".md",
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + "/RELEASE_NOTES.md",
           "References": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
-            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] +docLanguageUrl +
+            Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
             "/OtherMaterial-Reference.md",
         };
         const content = this.content();

--- a/src/views/SingleTool.vue
+++ b/src/views/SingleTool.vue
@@ -63,16 +63,16 @@
         const dict = {
           "Cli": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
           Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
-          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/8-Tools-Cli.md",
+          "/UserGuide/8-Tools-Cli.md",
           "Grafana": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
           Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
-          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/8-Tools-Grafana.md",
+          "/UserGuide/8-Tools-Grafana.md",
           "Hadoop": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
           Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
-          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/8-Tools-Hadoop.md",
+          "/UserGuide/8-Tools-Hadoop.md",
           "Spark": Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['doc-prefix'] +
           Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['branch'] + docLanguageUrl +
-          "/UserGuide" + Global.SUPPORT_VERSION[Global.DEFAULT_VERSION]['version'] + "/8-Tools-Spark.md",
+          "/UserGuide/8-Tools-spark.md",
         };
         const content = this.content();
         let url = null;


### PR DESCRIPTION
Delete `version` in documents folder and url, according to [PR #280](https://github.com/apache/incubator-iotdb/pull/280).
In the future, branch names will be used for documents versions on website.

For example, the url of User Guide document Chapter 1.1 will change as below:
previous: `https://raw.githubusercontent.com/apache/incubator-iotdb/master/docs/Documentation/UserGuideV0.8.0/1-Overview/1-What%20is%20IoTDB.md`

now: `https://raw.githubusercontent.com/apache/incubator-iotdb/rel/0.8/docs/Documentation/UserGuide/1-Overview/1-What%20is%20IoTDB.md`