### PR TITLE
[IOTDB-166] Update the download section (for v0.8) of the official website

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -9,12 +9,8 @@
       <article lang="en">
         <ol class="list-unstyled">
           <li>
-            1. After the Apache version is released, users are encouraged to read the overview of major changes in <router-link to="/Materials/Release%20Notes">release notes</router-link>,
-            download the version in <router-link to="/Download">download page</router-link>
-            and view documents in <router-link to="/Documents/Quick%20Start">documentation page</router-link>.
-          </li>
-          <li>
-            2. Currently, we support an unofficial version on <a href="https://github.com/thulab/iotdb/releases">GitHub</a>.
+            Apache IoTDB (Incubating) V0.8.0 is released. Users are encouraged to read the overview of major changes in <router-link to="/Materials/Release%20Notes">release notes</router-link>,
+            download the version in <router-link to="/Download">download page</router-link> and view documents in <router-link to="/Documents/Quick%20Start">documentation page</router-link>.
           </li>
         </ol>
       </article>

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -10,9 +10,16 @@
             </select>
           </p>
           <ul>
-            <li style="margin: 5px">Download IoTDB Binaries:<a class="link-color" :href="selectVersionObj.binariesUrl"> {{selectVersionObj.text}} Release</a></li>
-            <li style="margin: 5px">Download IoTDB Sources:<a class="link-color" :href="selectVersionObj.sourcesUrl"> {{selectVersionObj.text}} Sources</a></li>
-          </ul>
+            <li style="margin: 5px">Download IoTDB Binaries:<a class="link-color" :href="selectVersionObj.binariesUrl"> {{selectVersionObj.text}} Release</a>
+              <span v-if="selectVersionObj.binariesSHA512Url!==''">[<a class="link-color" :href="selectVersionObj.binariesSHA512Url"> SHA512</a>]</span>
+              <span v-if="selectVersionObj.binariesASCUrl!==''">[<a class="link-color" :href="selectVersionObj.binariesASCUrl"> ASC</a>]</span>
+            </li>
+            <li style="margin: 5px" v-if="selectVersionObj.sourcesUrl!==''">
+              Download IoTDB Sources:<a class="link-color" :href="selectVersionObj.sourcesUrl"> {{selectVersionObj.text}} Sources</a>
+              <span v-if="selectVersionObj.sourcesSHA512Url!==''">[<a class="link-color" :href="selectVersionObj.sourcesSHA512Url"> SHA512</a>]</span>
+              <span v-if="selectVersionObj.sourcesASCUrl!==''">[<a class="link-color" :href="selectVersionObj.sourcesASCUrl"> ASC</a>]</span>
+            </li>
+            </ul>
           <p>Main features and change list of each version, please check <router-link to="/Materials/Release Notes">release notes</router-link>.</p>
           <h2 class="download-title">Get Source Code</h2>
           <p>Go to our <a class="link-color" :href="iotdbGithubUrl">Github</a>, have fun with IoTDB source code!</p>
@@ -39,13 +46,21 @@
         selectVersionObj: {},
         downloadVersionList: [
           {text: 'IoTDB v0.8.0',
-            binariesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
-            sourcesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+            binariesUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip',
+            binariesSHA512Url: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.sha512',
+            binariesASCUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.asc',
+            sourcesUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip',
+            sourcesSHA512Url: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.sha512',
+            sourcesASCUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.asc'
           },
           {
             text: 'IoTDB v0.7.0',
             binariesUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
-            sourcesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+            binariesSHA512Url: '',
+            binariesASCUrl: '',
+            sourcesUrl: '',
+            sourcesSHA512Url: '',
+            sourcesASCUrl: ''
           },
         ]
       }

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -12,6 +12,7 @@
           <ul>
             <li style="margin: 5px">Download IoTDB for Linux/MacOS:<a class="link-color" :href="selectVersionObj.linuxUrl"> {{selectVersionObj.text}} Release.tar</a></li>
             <li style="margin: 5px">Download IoTDB for Windows:<a class="link-color" :href="selectVersionObj.windowsUrl"> {{selectVersionObj.text}} Release.zip</a></li>
+            <li style="margin: 5px">Download IoTDB sources:<a class="link-color" :href="selectVersionObj.sourceUrl"> {{selectVersionObj.text}} Source</a></li>
           </ul>
           <p>Main features and change list of each version, please check <router-link to="/Materials/Release Notes">release notes</router-link>.</p>
           <h2 class="download-title">Get Source Code</h2>
@@ -38,7 +39,17 @@
         iotdbGithubUrl: 'https://github.com/apache/incubator-iotdb',
         selectVersionObj: {},
         downloadVersionList: [
-          {text: 'IoTDB v0.8.0', linuxUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/', windowsUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'},
+          {text: 'IoTDB v0.8.0',
+            linuxUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
+            windowsUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
+            sourceUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+          },
+          {
+            text: 'IoTDB v0.7.0',
+            linuxUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
+            windowsUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
+            sourceUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+          },
         ]
       }
     },

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -10,9 +10,8 @@
             </select>
           </p>
           <ul>
-            <li style="margin: 5px">Download IoTDB for Linux/MacOS:<a class="link-color" :href="selectVersionObj.linuxUrl"> {{selectVersionObj.text}} Release.tar</a></li>
-            <li style="margin: 5px">Download IoTDB for Windows:<a class="link-color" :href="selectVersionObj.windowsUrl"> {{selectVersionObj.text}} Release.zip</a></li>
-            <li style="margin: 5px">Download IoTDB sources:<a class="link-color" :href="selectVersionObj.sourceUrl"> {{selectVersionObj.text}} Source</a></li>
+            <li style="margin: 5px">Download IoTDB Binaries:<a class="link-color" :href="selectVersionObj.binariesUrl"> {{selectVersionObj.text}} Release</a></li>
+            <li style="margin: 5px">Download IoTDB Sources:<a class="link-color" :href="selectVersionObj.sourcesUrl"> {{selectVersionObj.text}} Sources</a></li>
           </ul>
           <p>Main features and change list of each version, please check <router-link to="/Materials/Release Notes">release notes</router-link>.</p>
           <h2 class="download-title">Get Source Code</h2>
@@ -40,15 +39,13 @@
         selectVersionObj: {},
         downloadVersionList: [
           {text: 'IoTDB v0.8.0',
-            linuxUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
-            windowsUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
-            sourceUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+            binariesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/',
+            sourcesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
           },
           {
             text: 'IoTDB v0.7.0',
-            linuxUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
-            windowsUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
-            sourceUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
+            binariesUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0',
+            sourcesUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'
           },
         ]
       }

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -46,12 +46,12 @@
         selectVersionObj: {},
         downloadVersionList: [
           {text: 'IoTDB v0.8.0',
-            binariesUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip',
-            binariesSHA512Url: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.sha512',
-            binariesASCUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.asc',
-            sourcesUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip',
-            sourcesSHA512Url: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.sha512',
-            sourcesASCUrl: 'https://archive.apache.org/dist/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.asc'
+            binariesUrl: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip',
+            binariesSHA512Url: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.sha512',
+            binariesASCUrl: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-bin.zip.asc',
+            sourcesUrl: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip',
+            sourcesSHA512Url: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.sha512',
+            sourcesASCUrl: 'https://www.apache.org/dyn/closer.cgi/incubator/iotdb/0.8.0-incubating/apache-iotdb-0.8.0-incubating-source-release.zip.asc'
           },
           {
             text: 'IoTDB v0.7.0',
@@ -111,4 +111,3 @@
     font-size: 16px;
   }
 </style>
-

--- a/src/views/Download.vue
+++ b/src/views/Download.vue
@@ -13,9 +13,7 @@
             <li style="margin: 5px">Download IoTDB for Linux/MacOS:<a class="link-color" :href="selectVersionObj.linuxUrl"> {{selectVersionObj.text}} Release.tar</a></li>
             <li style="margin: 5px">Download IoTDB for Windows:<a class="link-color" :href="selectVersionObj.windowsUrl"> {{selectVersionObj.text}} Release.zip</a></li>
           </ul>
-          <p>(Note that before v0.7.0 (included), IoTDB had not yet become an incubator project in Apache. Above is an unofficial release
-            since our first official release is still in progress.)</p>
-          <p>Main features and change list of each version, please check <router-link to="/Materials/Release Notes">release notes</router-link></p>
+          <p>Main features and change list of each version, please check <router-link to="/Materials/Release Notes">release notes</router-link>.</p>
           <h2 class="download-title">Get Source Code</h2>
           <p>Go to our <a class="link-color" :href="iotdbGithubUrl">Github</a>, have fun with IoTDB source code!</p>
         </div>
@@ -40,7 +38,7 @@
         iotdbGithubUrl: 'https://github.com/apache/incubator-iotdb',
         selectVersionObj: {},
         downloadVersionList: [
-          {text: 'IoTDB v0.7.0', linuxUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0', windowsUrl: 'https://github.com/thulab/iotdb/releases/tag/v0.7.0'},
+          {text: 'IoTDB v0.8.0', linuxUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/', windowsUrl: 'https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/'},
         ]
       }
     },


### PR DESCRIPTION
As is mentioned in issue [IOTDB-166](https://issues.apache.org/jira/browse/IOTDB-166), since the v0.8.0 is released, we can update the download section in the official website, and remove v0.7.0 which is not an apache official version.

Currently the download link points to [here](https://dist.apache.org/repos/dist/dev/incubator/iotdb/0.8.0/rc3/), and after the release is formally released, the link will be changed to the latest one.