### PR TITLE
[IOTDB-183] Split Development pages and add "latest" version

### DIFF
--- a/src/components/Global.vue
+++ b/src/components/Global.vue
@@ -18,6 +18,12 @@
       "doc-prefix": DOC_URL_PREFIX,
       'text': "V0.8.0",
       'content': '0-Content.md'
+    },
+    "latest": {
+      "branch": "master",
+      "doc-prefix": DOC_URL_PREFIX,
+      'text': "Latest",
+      'content': '0-Content.md'
     }
   };
 

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -57,8 +57,15 @@
                 </li>
               </ul>
             </li>
-            <li class="nav-item">
-              <router-link to="/Development" class="nav-link"><span>Development</span></router-link>
+            <li class="dropdown">
+              <router-link to="/Development/Contributing" class="dropdown-toggle" data-toggle="dropdown" role="button"
+                           aria-haspopup="true" aria-expanded="false"><span>Development<b class="caret"></b></span>
+              </router-link>
+              <ul class="dropdown-menu">
+                <li v-for="item in Development">
+                  <router-link :to=item.url class="nav-link"><span>{{item.content}}</span></router-link>
+                </li>
+              </ul>
             </li>
             <li class="nav-item">
               <router-link to="/Example" class="nav-link"><span>Example</span></router-link>
@@ -120,6 +127,12 @@
           {"url": "/Tools/Hadoop", "content": "Hadoop Connector"},
           {"url": "/Tools/Spark", "content": "Spark Connector"}
         ],
+        "Development": [
+          {"url": "/Development/Contributing", "content": "Questions and Contributing"},
+          {"url": "/Development/IDE", "content": "Developing in IDE"},
+          {"url": "/Development/Tsfile", "content": "Changelist of Tsfile"},
+          {"url": "/Development/RPC", "content": "Changelist of RPC"}
+        ]
       }
     },
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -34,7 +34,7 @@ export default new Router({
     },
     {
       path: '/Documents/:version/:chapter?/:section?',
-      name: 'Documents',
+      name: 'UserGuideDocuments',
       component: Documents
     },
     {
@@ -44,7 +44,7 @@ export default new Router({
     },
     {
       path: '/Materials/:doc',
-      name: 'Materials',
+      name: 'SingleMaterial',
       component: SingleMaterials
     },
     {
@@ -63,7 +63,7 @@ export default new Router({
       component: Community
     },
     {
-      path: '/Development',
+      path: '/Development/:content',
       name: 'Development',
       component: Development
     },

--- a/src/views/Development.vue
+++ b/src/views/Development.vue
@@ -22,7 +22,7 @@
   import SideBar from '../components/SideBar'
   import markdown from 'vue-markdown'
   import axios from 'axios'
-  import Golbal from '../components/Global'
+  import Global from '../components/Global'
   import LoadingBar from '../components/Loading'
 
   export default {
@@ -53,10 +53,24 @@
         return this.$route.params.content
       },
       fetchData() {
-        let url = Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['doc-prefix'] +
-          Golbal.SUPPORT_VERSION[Golbal.DEFAULT_VERSION]['branch'] +
-          "/docs/Development.md";
-        let pointer = this;
+        const dict = {
+          "Contributing": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development.md",
+          "IDE": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development.md",
+          "Tsfile": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/tsfile/format-changelist.md",
+          "RPC": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/service-rpc/rpc-changelist.md",
+        };
+        const content = this.content();
+        let url = null;
+        if (content in dict) {
+          url = dict[content];
+        } else {
+          this.$router.push('/404');
+        }
+        const pointer = this;
         this.seen = true;
         axios.get(url).then(function (response) {
           pointer.md = response.data;
@@ -64,7 +78,7 @@
         })
       },
       parse(html){
-        return Golbal.isReadyForPrerender(html)
+        return Global.isReadyForPrerender(html)
       }
     }
   }

--- a/src/views/Development.vue
+++ b/src/views/Development.vue
@@ -55,9 +55,9 @@
       fetchData() {
         const dict = {
           "Contributing": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
-          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development.md",
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development-Contributing.md",
           "IDE": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
-          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development.md",
+          Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/docs/Development-IDE.md",
           "Tsfile": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +
           Global.SUPPORT_VERSION[Global.LATEST_STR]['branch'] + "/tsfile/format-changelist.md",
           "RPC": Global.SUPPORT_VERSION[Global.LATEST_STR]['doc-prefix'] +

--- a/src/views/Documents.vue
+++ b/src/views/Documents.vue
@@ -132,7 +132,10 @@
         return this.$route.params.section;
       },
       updateDocument(){
-        this.text = this.getVersionString();
+        if (this.text !== this.getVersionString()) {
+          this.text = this.getVersionString();
+          location.reload();
+        }
       },
       switchLanguage()  {
         this.eng = this.eng !== true;


### PR DESCRIPTION
Now that more and more contents are added to Development page (like [change list of Tsfile and RPC](https://github.com/apache/incubator-iotdb/pull/359)), we consider to adjust the website nav bar and split Development documents into several sub pages like other pages.
![new nav bar](https://user-images.githubusercontent.com/19167280/63837357-e9c46c00-c9ad-11e9-9196-25374d46fe44.png)

Besides, since change list needs to be updated in real time, "latest version" is introduced besides "V0.8.0", which will leads to branch `rel/0.8`. Some new features after V0.8.0 (like [new interfaces in session](https://issues.apache.org/jira/browse/IOTDB-173) and [status code](https://issues.apache.org/jira/browse/IOTDB-161)) could be found in latest documents, too.
<img width="500" alt="latest version" src="https://user-images.githubusercontent.com/19167280/63837376-f5179780-c9ad-11e9-910d-0bf728953d35.png">