### PR TITLE
[IOTDB-362] fix link error for Community.vue.

### DIFF
--- a/src/views/Community.vue
+++ b/src/views/Community.vue
@@ -9,7 +9,7 @@
         <my-sidebar/>
       </div>
       <div class="col-sm-8" v-if="this.content()==='Project Committers'">
-        <router-link  to="/Development" class="nav-link"><span style="font-size: medium">Want to join us? Learn How to Contribute </span>
+        <router-link  to="/Development/Contributing" class="nav-link"><span style="font-size: medium">Want to join us? Learn How to Contribute </span>
         </router-link>
       </div>
     </div>


### PR DESCRIPTION
Get 404 error when click the link for "Want to join us? Learn How to Contribute " at the bottom of the page [https://iotdb.apache.org/#/Community/Project%20Committers](https://iotdb.apache.org/#/Community/Project%20Committers)
i.e., "https://iotdb.apache.org/#/Development" not found.

I think we should change the link from "https://iotdb.apache.org/#/Development" to "https://iotdb.apache.org/#/Development/Contributing" . 