### PR TITLE
[IOTDB-382] Fix insecure script requested error in home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
       <p>
         Along with our releases, we also provide sha512 hashes in *.sha512 files and
         cryptographic signatures in *.asc files. The Apache Software Foundation has an extensive
-        tutorial to <a data-v-760dd6c2="" href="http://www.apache.org/info/verification.html" class="link-color">
+        tutorial to <a data-v-760dd6c2="" href="https://www.apache.org/info/verification.html" class="link-color">
         verify
         hashes and signatures </a> which you can follow by using any of these
         release-signing <a data-v-760dd6c2="" href="https://www.apache.org/dist/incubator/iotdb/KEYS"

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 </noscript>
 </body>
 
-<script src="http://libs.baidu.com/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://libs.baidu.com/jquery/2.1.1/jquery.min.js"></script>
 
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"


### PR DESCRIPTION
when we open the home page of IoTDB(https://iotdb.apache.org/), but when we debug the resource loading, I found that there is a Insecure script requested error as follows:

`Mixed Content: The page at 'https://iotdb.apache.org/#/' was loaded over HTTPS, but requested an insecure script 'http://libs.baidu.com/jquery/2.1.1/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.`

I think we should using "https" for download the JS script. 
