### PR TITLE
[IOTDB-384] Fix main feature text style in homepage

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,8 +1,13 @@
 <template>
   <div class="col-sm-3  blog-sidebar">
     <div class="github-button-group">
-      <github-button class="github-button" href="https://github.com/apache/incubator-iotdb/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork apache/incubator-iotdb on GitHub">Fork</github-button>
-      <github-button class="github-button" href="https://github.com/apache/incubator-iotdb" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star apache/incubator-iotdb on GitHub">Star</github-button>
+      <github-button class="github-button" href="https://github.com/apache/incubator-iotdb/fork"
+                     data-icon="octicon-repo-forked" data-size="large" data-show-count="true"
+                     aria-label="Fork apache/incubator-iotdb on GitHub">Fork
+      </github-button>
+      <github-button class="github-button" href="https://github.com/apache/incubator-iotdb" data-icon="octicon-star"
+                     data-size="large" data-show-count="true" aria-label="Star apache/incubator-iotdb on GitHub">Star
+      </github-button>
     </div>
     <div class="sidebar-module sidebar-module-inset">
       <h4>Latest News</h4>
@@ -10,8 +15,13 @@
         <ol class="list-unstyled">
           <li>
             Apache IoTDB (Incubating) V0.9.0 is released. Users are encouraged to read the overview of major changes in
-            <a class="link-color" href="https://raw.githubusercontent.com/apache/incubator-iotdb/release/0.9.0/RELEASE_NOTES.md">release notes</a>,
-            download the version in <router-link to="/Download">download page</router-link> and view documents in <router-link to="/Documents/0.9.0/chap1/sec1">documentation page</router-link>.
+            <a class="link-color"
+               href="https://raw.githubusercontent.com/apache/incubator-iotdb/release/0.9.0/RELEASE_NOTES.md">release notes</a>,
+            download the version in
+            <router-link to="/Download">download page</router-link>
+            and view documents in
+            <router-link to="/Documents/0.9.0/chap1/sec1">documentation page</router-link>
+            .
             It is recommended to back up your data before online upgrading from 0.8.*.
           </li>
         </ol>
@@ -21,7 +31,8 @@
     <router-link to="/Download" class="nav-link btn btn-lg btn-block btn-warning button" style="color: white">
       <span>Download</span>
     </router-link>
-    <router-link to="/Documents/Quick%20Start" class="nav-link btn btn-white btn-lg btn-block button"><span>Quick Start</span></router-link>
+    <router-link to="/Documents/Quick%20Start" class="nav-link btn btn-white btn-lg btn-block button">
+      <span>Quick Start</span></router-link>
   </div><!-- /.blog-sidebar -->
 </template>
 
@@ -42,22 +53,26 @@
     padding: 15px;
     margin-bottom: 15px;
   }
+
   .sidebar-module-inset {
     padding: 15px;
     background-color: #f5f5f5;
     border-radius: 4px;
   }
+
   .sidebar-module-inset p:last-child,
   .sidebar-module-inset ul:last-child,
   .sidebar-module-inset ol:last-child {
     margin-bottom: 0;
   }
+
   .button {
     width: 100%;
     font-size: large;
     font-weight: bold;
   }
-  .blog-sidebar{
+
+  .blog-sidebar {
     top: 2px;
   }
 
@@ -68,7 +83,7 @@
   }
 
   .btn-white:hover {
-    background-color: rgb(238,163, 69);
+    background-color: rgb(238, 163, 69);
   }
 
   .sidebar-module {
@@ -100,5 +115,9 @@
 
   .github-button {
     margin: 7px;
+  }
+
+  .list-unstyled {
+    text-align: left;
   }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -89,7 +89,7 @@
                   </div>
                   <div class="col-xs-10 col-sm-10 feature-title"><p>{{item.featureTitle}}</p></div>
                 </div>
-                  <p class="feature-content" style="text-align: justify">{{item.featureContent}}</p>
+                  <p class="feature-content">{{item.featureContent}}</p>
                 <hr/>
               </div>
             </div>


### PR DESCRIPTION
Change main feature text style in homepage by removing `text-align: justify`.

Before:
<img width="880" alt="截屏2019-12-2320 45 41" src="https://user-images.githubusercontent.com/19167280/71358857-661a3500-25c5-11ea-9a63-00da0e76f2c8.png">

After:
<img width="886" alt="截屏2019-12-2320 45 33" src="https://user-images.githubusercontent.com/19167280/71358851-61558100-25c5-11ea-9f10-d0aee9d49788.png">
